### PR TITLE
Add server extension using h5grove to replace jupyterlab_hdf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           pip install .
           jupyter lab build
           jupyter serverextension list 1>serverextensions 2>&1
-          cat serverextensions | grep "jupyterlab_hdf.*OK"
+          cat serverextensions | grep "jupyterlab_h5web.*OK"
           jupyter labextension list 1>labextensions 2>&1
           cat labextensions | grep "jupyterlab-h5web.*OK"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The `jlpm` command is JupyterLab's pinned version of
 
 # Install package in development mode
 pip install -e .
-# Ensure that `jupyterlab_hdf` server extension is present and enabled
+# Ensure that `jupyterlab_h5web` server extension is present and enabled
 jupyter serverextension list
 
 # Install dependencies
@@ -51,8 +51,7 @@ This extension uses `prettier` to format `*.ts` files and `black` to format
 
 ### Why a Python package for a front-end extension ?
 
-1. To ease up installation (e.g. automatic resolution of the `jupyter_hdf` PyPI
-   package)
+1. To ease up installation
 2. To get ready to release a pre-built extension (_JupyterLab 3_)
 
 The pre-built extension will indeed remove the need for `node`. For _JupyterLab

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ See https://github.com/silx-kit/jupyterlab-h5web/releases.
 ### Check the server extension
 
 If you are seeing the frontend extension but it is not working, check that
-`jupyterlab_hdf` is installed and enabled.
+`jupyterlab_h5web` is installed and enabled.
 
 It should be listed when running:
 
@@ -124,21 +124,15 @@ It should be listed when running:
 jupyter serverextension list
 ```
 
-If `jupyterlab_hdf` does not appear, try to install it manually:
+If `jupyterlab_h5web` does not appear or is disabled, try to enable it:
 
 ```
-pip install jupyterlab_hdf
-```
-
-and to enable it:
-
-```
-jupyter serverextension enable jupyterlab_hdf
+jupyter serverextension enable jupyterlab_h5web
 ```
 
 ### Check the frontend extension
 
-If `jupyterlab_hdf` is installed and enabled but you are not seeing the
+If `jupyterlab_h5web` is installed and enabled but you are not seeing the
 frontend, check the frontend is installed:
 
 ```bash

--- a/jupyter-config/jupyterlab-h5web.json
+++ b/jupyter-config/jupyterlab-h5web.json
@@ -1,7 +1,7 @@
 {
   "NotebookApp": {
     "nbserver_extensions": {
-      "jupyterlab_hdf": true
+      "jupyterlab_h5web": true
     }
   }
 }

--- a/jupyterlab_h5web/__init__.py
+++ b/jupyterlab_h5web/__init__.py
@@ -1,1 +1,19 @@
 from .widget import H5Web
+
+
+def _jupyter_server_extension_points():
+    return [{"module": "jupyterlab_h5web"}]
+
+
+def _load_jupyter_server_extension(server_app):
+    """Registers the API handler to receive HTTP requests from the frontend extension."""
+    from .handlers import setup_handlers
+
+    setup_handlers(server_app.web_app, server_app.notebook_dir)
+    server_app.log.info(
+        f"Jupyterlab-h5web extension will serve HDF5 files from {server_app.notebook_dir}"
+    )
+
+
+# For backward compatibility with notebook server - useful for Binder/JupyterHub
+load_jupyter_server_extension = _load_jupyter_server_extension

--- a/jupyterlab_h5web/handlers.py
+++ b/jupyterlab_h5web/handlers.py
@@ -1,0 +1,72 @@
+import h5py
+import tornado.web
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.utils import url_path_join
+from pathlib import Path
+
+from h5grove.encoders import encode
+from h5grove.content import create_content, ResolvedEntityContent, DatasetContent
+
+from .utils import as_absolute_path
+
+
+class BaseHandler(APIHandler):
+    def initialize(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+    @tornado.web.authenticated
+    def get(self, file_path: str):
+        path = self.get_query_argument("path", None)
+        format = self.get_query_argument("format", None)
+
+        with h5py.File(as_absolute_path(self.base_dir, Path(file_path)), "r") as h5file:
+            content = self.get_content(h5file, path)
+
+        encoded_content_chunks, headers = encode(content, format)
+
+        for key, value in headers.items():
+            self.set_header(key, value)
+        for chunk in encoded_content_chunks:
+            self.write(chunk)
+        self.finish()
+
+    def get_content(self, h5file, path):
+        raise NotImplementedError
+
+
+class AttributeHandler(BaseHandler):
+    def get_content(self, h5file, path):
+        content = create_content(h5file, path)
+        assert isinstance(content, ResolvedEntityContent)
+        return content.attributes()
+
+
+class DataHandler(BaseHandler):
+    def get_content(self, h5file, path):
+        selection = self.get_query_argument("selection", None)
+
+        content = create_content(h5file, path)
+        assert isinstance(content, DatasetContent)
+        return content.data(selection)
+
+
+class MetadataHandler(BaseHandler):
+    def get_content(self, h5file, path):
+        content = create_content(h5file, path)
+        return content.metadata()
+
+
+def setup_handlers(web_app, base_dir: str):
+    pattern = "(.*)"
+    endpoints = {"attr": AttributeHandler, "data": DataHandler, "meta": MetadataHandler}
+
+    handlers = [
+        (
+            url_path_join(web_app.settings["base_url"], "h5web", endpoint, pattern),
+            handler,
+            {"base_dir": Path(base_dir)},
+        )
+        for endpoint, handler in endpoints
+    ]
+
+    web_app.add_handlers(pattern, handlers)

--- a/jupyterlab_h5web/utils.py
+++ b/jupyterlab_h5web/utils.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def as_absolute_path(base_dir: Path, file_path: Path) -> Path:
+    if file_path.is_absolute():
+        return file_path
+
+    return base_dir / file_path

--- a/jupyterlab_h5web/widget.py
+++ b/jupyterlab_h5web/widget.py
@@ -1,21 +1,22 @@
-import os.path
 from pathlib import Path
 from typing import Dict, Tuple, Union
 from IPython.core.display import DisplayObject
+from .utils import as_absolute_path
 
 
 class H5Web(DisplayObject):
     mimetype = "application/x-hdf5"
 
-    def __init__(self, data: Union[str, Path], **kwargs) -> None:
+    def __init__(self, file_path: Union[str, Path], **kwargs) -> None:
         # "Data" here is the path to the HDF5 file.
-        self.data = data
+        self.data = as_absolute_path(Path.cwd(), Path(file_path))
         self.metadata = {}
         if kwargs:
             self.metadata.update(kwargs)
+        self._check_data()
 
     def _check_data(self) -> None:
-        if not os.path.isfile(self.data):
+        if not self.data.is_file():
             raise FileNotFoundError(f"{self.data} is not a valid file.")
 
     def _repr_mimebundle_(

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "postversion": "git push && git push --tags"
   },
   "dependencies": {
-    "@h5web/app": "0.0.18",
+    "@h5web/app": "0.0.23",
     "@jupyterlab/application": "^2.0.0 || ^3.0.0",
     "@jupyterlab/apputils": "~2.3.0 || ^3.0.5",
     "@jupyterlab/coreutils": "^4.0.0 || ^5.0.0",
@@ -76,16 +76,6 @@
     "style/*.css"
   ],
   "jupyterlab": {
-    "discovery": {
-      "server": {
-        "managers": [
-          "pip"
-        ],
-        "base": {
-          "name": "jupyterlab_hdf"
-        }
-      }
-    },
     "extension": true
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
-    install_requires=["jupyterlab_hdf"],
+    install_requires=["jupyter_server>=1.6,<2", "h5grove"],
     extras_require={"full": ["hdf5plugin"]},
     python_requires=">=3.6",
     zip_safe=False,

--- a/src/H5webApp.tsx
+++ b/src/H5webApp.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { App, JupyterProvider } from '@h5web/app';
+import { App, H5CoreProvider as H5GroveProvider } from '@h5web/app';
 import { ServerConnection } from '@jupyterlab/services';
 
 // Render the App twice on mount as the CSS is not loaded at first render.
@@ -23,12 +23,12 @@ function H5webApp(props: { filePath: string }) {
 
   return (
     <div className="h5web-root">
-      <JupyterProvider
-        url={baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl}
+      <H5GroveProvider
+        url={`${baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl}/h5web`}
         filepath={filePath}
       >
         <TwoRenderApp />
-      </JupyterProvider>
+      </H5GroveProvider>
     </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,6 +224,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.13.10":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
+  integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -310,10 +317,13 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.1.tgz#ccfef6ddbe59f8fe8f694783e1d3eb88902dc5eb"
   integrity sha512-OEdH7SyC1suTdhBGW91/zBfR6qaIhThbcN8PUXtXilY4GYnSBbVqOntdHbC1vXwsDnX0Qix2m2+DSU1J51ybOQ==
 
-"@h5web/app@0.0.18":
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/@h5web/app/-/app-0.0.18.tgz#65d9145a9a84d026df2ef32b79bfc68bd07fcd45"
-  integrity sha512-74q3WA3hy/CDHtzUY/I5HPDGPfWe974CHOjxrHu45yTcSqGg7atXXStM9NB+ftWQEZvEuqcKJr+J5iyCJ926Ng==
+"@h5web/app@0.0.23":
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/@h5web/app/-/app-0.0.23.tgz#90060caf1239f1c9d8abe0e2af01fe30a2c7ad06"
+  integrity sha512-4iahpPb4A0ucI4deH/9e7AiJBBaRVaHeuLw3KIWzmoXgYWf19NpLueFfW1tBd5Jib/YTb+10zblen9hfcfY9eA==
+  dependencies:
+    "@react-three/fiber" "^7.0.1"
+    three "^0.129.0"
 
 "@jest/types@^26.6.2":
   version "26.6.2"
@@ -796,6 +806,22 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
+
+"@react-three/fiber@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@react-three/fiber/-/fiber-7.0.1.tgz#d7b5db1c4b45fe90442647f88dff1906e56ccfd9"
+  integrity sha512-UrC5wVywYAHIvcfHEreJXqDZJvQTFSuB737MBv1VliI4d1S0MbSLG9hOCDaWWgX9Wq+6jvVxG2JNfGXvZK1ATQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    react-merge-refs "^1.1.0"
+    react-reconciler "^0.26.2"
+    react-three-fiber "0.0.0-deprecated"
+    react-use-measure "^2.0.4"
+    resize-observer-polyfill "^1.5.1"
+    scheduler "^0.20.2"
+    use-asset "^1.0.4"
+    utility-types "^3.10.0"
+    zustand "^3.5.1"
 
 "@testing-library/dom@^7.28.1":
   version "7.30.1"
@@ -1385,6 +1411,11 @@ damerau-levenshtein@^1.0.6:
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
   integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
 
+debounce@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
+
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1882,7 +1913,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -2874,6 +2905,11 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-merge-refs@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
+  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+
 react-popper@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"
@@ -2887,6 +2923,20 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
+react-reconciler@^0.26.2:
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.2.tgz#bbad0e2d1309423f76cf3c3309ac6c96e05e9d91"
+  integrity sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
+react-three-fiber@0.0.0-deprecated:
+  version "0.0.0-deprecated"
+  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-0.0.0-deprecated.tgz#c737242487d824cf9520307308b7e4c4071a278f"
+  integrity sha512-EblIqTAsIpkYeM8bZtC4lcpTE0A2zCEGipFB52RgcQq/q+0oryrk7Sxt+sqhIjUu6xMNEVywV8dr74lz5yWO6A==
+
 react-transition-group@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
@@ -2896,6 +2946,13 @@ react-transition-group@^2.9.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-use-measure@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.4.tgz#cb675b36eaeaf3681b94d5f5e08b2a1e081fedc9"
+  integrity sha512-7K2HIGaPMl3Q9ZQiEVjen3tRXl4UDda8LiTPy/QxP8dP2rl5gPBhf7mMH6MVjjRNv3loU7sNzey/ycPNnHVTxQ==
+  dependencies:
+    debounce "^1.2.0"
 
 react@^17.0.1, "react@~16.9.0 || ^17.0.1":
   version "17.0.2"
@@ -3290,6 +3347,11 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+three@^0.129.0:
+  version "0.129.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.129.0.tgz#f5e530bbc96eac5d5b4749cb5da886ef0d42f554"
+  integrity sha512-wiWio1yVRg2Oj6WEWsTHQo5eSzYpEwSBtPSi3OofNpvFbf26HFfb9kw4FZJNjII4qxzp0b1xLB11+tKkBGB1ZA==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -3407,6 +3469,18 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-asset@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/use-asset/-/use-asset-1.0.4.tgz#506caafc29f602890593799e58b577b70293a6e2"
+  integrity sha512-7/hqDrWa0iMnCoET9W1T07EmD4Eg/Wmoj/X8TGBc++ECRK4m5yTsjP4O6s0yagbxfqIOuUkIxe2/sA+VR2GxZA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
+utility-types@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
+  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
+
 v8-compile-cache@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
@@ -3480,3 +3554,8 @@ yarn-deduplicate@^3.1.0:
     "@yarnpkg/lockfile" "^1.1.0"
     commander "^6.1.0"
     semver "^7.3.2"
+
+zustand@^3.5.1:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.5.2.tgz#cf162a8bd1d86475bf308bc856c4d02ff13fd53c"
+  integrity sha512-HUCQI9O77/D/zvoWPNv4dwLriiiY2xtEqnQ0TVY8uaPjmOHls04Okd0w3sWUE9Ex2LaYlSk11DbPPIOZ6shEWg==


### PR DESCRIPTION
Also:
- Update h5web to 0.0.23 (needed for `H5CoreProvider`, alias to `H5GroveProvider` to match the project renaming)
- H5Web widgets resolve file paths according to notebook location (was JupyterLab server location before)