### PR TITLE
Fixing H5Web support of filenames with special characters

### DIFF
--- a/jupyterlab_h5web/widget.py
+++ b/jupyterlab_h5web/widget.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from typing import Dict, Tuple, Union
-from urllib.parse import quote_plus, unquote_plus
+from urllib.parse import quote_plus
 from IPython.core.display import DisplayObject
 from .utils import as_absolute_path
 
@@ -11,16 +11,12 @@ class H5Web(DisplayObject):
     def __init__(self, file_path: Union[str, Path], **kwargs) -> None:
         # "Data" here is the path to the HDF5 file.
         absolute_file_path = as_absolute_path(Path.cwd(), Path(file_path))
+        if not absolute_file_path.is_file():
+            raise FileNotFoundError(f"{absolute_file_path} is not a valid file.")
         self.data = quote_plus(str(absolute_file_path), safe="/")
         self.metadata = {}
         if kwargs:
             self.metadata.update(kwargs)
-        self._check_data()
-
-    def _check_data(self) -> None:
-        file_path = Path(unquote_plus(self.data))
-        if not file_path.is_file():
-            raise FileNotFoundError(f"{file_path} is not a valid file.")
 
     def _repr_mimebundle_(
         self, include=None, exclude=None

--- a/jupyterlab_h5web/widget.py
+++ b/jupyterlab_h5web/widget.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Dict, Tuple, Union
+from urllib.parse import quote_plus, unquote_plus
 from IPython.core.display import DisplayObject
 from .utils import as_absolute_path
 
@@ -9,15 +10,17 @@ class H5Web(DisplayObject):
 
     def __init__(self, file_path: Union[str, Path], **kwargs) -> None:
         # "Data" here is the path to the HDF5 file.
-        self.data = as_absolute_path(Path.cwd(), Path(file_path))
+        absolute_file_path = as_absolute_path(Path.cwd(), Path(file_path))
+        self.data = quote_plus(str(absolute_file_path), safe="/")
         self.metadata = {}
         if kwargs:
             self.metadata.update(kwargs)
         self._check_data()
 
     def _check_data(self) -> None:
-        if not self.data.is_file():
-            raise FileNotFoundError(f"{self.data} is not a valid file.")
+        file_path = Path(unquote_plus(self.data))
+        if not file_path.is_file():
+            raise FileNotFoundError(f"{file_path} is not a valid file.")
 
     def _repr_mimebundle_(
         self, include=None, exclude=None


### PR DESCRIPTION
This PR escapes the filename in `H5Web` so it is safely pass through the request.

As it is, the file path displayed in h5web is also escaped so it is no really nice, but looks to work.

If you prefer to keep `_check_data`, I'll remove the 2nd commit.

closes #45