### PR TITLE
Intercept opening events to bypass the base64 blob fetching

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,131 @@
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { MainAreaWidget } from '@jupyterlab/apputils';
+import { PathExt } from '@jupyterlab/coreutils';
+import { DirListing, FileBrowser } from '@jupyterlab/filebrowser';
+import { Contents } from '@jupyterlab/services';
+
+import HDF5_FILE_TYPE from './fileType';
+import { h5webIcon } from './icons';
+import H5webWidgetFactory, { H5webWidget } from './widget';
+
+const OPEN_H5WEB_COMMAND = 'h5web-open';
+
+// Patch the opening of HDF5 files. This is to bypass the core JupyterLab circuitry that fetches the base64 blob (see the comment in fileType.ts)
+const PATCH_OPENING = true;
+
+export function getBrowserListing(browser: FileBrowser): DirListing {
+  if ('listing' in browser) {
+    // @ts-ignore
+    return browser.listing; // JLab 3
+  }
+
+  // @ts-ignore
+  return browser._listing; // JLab 2
+}
+
+// Reimplementation of the double-click/Enter handling that adds the special handling for HDF files
+// https://github.com/jupyterlab/jupyterlab/blob/256d18253ec2733431a3289691b6a16766d4469c/packages/filebrowser/src/listing.ts#L1006
+export function patchOpeningOfHdf5File(
+  app: JupyterFrontEnd,
+  browser: FileBrowser
+): void {
+  const { commands } = app;
+  const listing = getBrowserListing(browser);
+
+  // Reimplementation of handleOpen that add the special handling for HDF files
+  // https://github.com/jupyterlab/jupyterlab/blob/2.3.x/packages/filebrowser/src/listing.ts#L935
+  function handleOpen(item: Contents.IModel, event: Event): void {
+    if (!item) {
+      return;
+    }
+
+    const extname = PathExt.extname(item.path);
+    if (HDF5_FILE_TYPE.extensions.includes(extname)) {
+      commands.execute(OPEN_H5WEB_COMMAND);
+    } else {
+      // If it is not a HDF5 file, handle the event "normally"
+      listing.handleEvent(event);
+    }
+  }
+
+  function handleDblClick(evt: Event): void {
+    const event = evt as MouseEvent;
+    // Do nothing if it's not a left mouse press.
+    if (event.button !== 0) {
+      return;
+    }
+
+    // Do nothing if any modifier keys are pressed.
+    if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+      return;
+    }
+
+    // Stop the event propagation.
+    event.preventDefault();
+    event.stopPropagation();
+
+    const item = browser.modelForClick(event);
+    handleOpen(item, event);
+  }
+
+  function handleKeyDown(evt: Event): void {
+    const event = evt as KeyboardEvent;
+    if (event.key !== 'Enter') {
+      listing.handleEvent(event);
+      return;
+    }
+
+    if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+
+    const item = browser.selectedItems().next();
+    handleOpen(item, event);
+  }
+
+  browser.node.addEventListener('dblclick', handleDblClick, true);
+  browser.node.addEventListener('keydown', handleKeyDown, true);
+}
+
+export function activateOpenInBrowser(
+  app: JupyterFrontEnd,
+  browser: FileBrowser
+) {
+  const { commands } = app;
+  commands.addCommand(OPEN_H5WEB_COMMAND, {
+    label: 'View HDF5 file contents',
+    caption: 'Explore and visualize the contents of the HDF5 file',
+    icon: h5webIcon,
+    execute: () => {
+      const file = browser.selectedItems().next();
+
+      const content = new H5webWidget(file.path);
+      const widget = new MainAreaWidget<H5webWidget>({ content });
+      widget.title.label = file.name;
+      app.shell.add(widget, 'main');
+    },
+  });
+
+  if (PATCH_OPENING) {
+    patchOpeningOfHdf5File(app, browser);
+
+    // Add a context menu entry as not calling `addWidgetFactory` removes the "Open with... h5web" entry
+    app.contextMenu.addItem({
+      command: OPEN_H5WEB_COMMAND,
+      selector: `.jp-DirListing-item[data-file-type="${HDF5_FILE_TYPE.name}"]`,
+      rank: 0,
+    });
+  } else {
+    app.docRegistry.addWidgetFactory(
+      new H5webWidgetFactory({
+        defaultFor: [HDF5_FILE_TYPE.name],
+        fileTypes: [HDF5_FILE_TYPE.name],
+        name: 'jupyterlab-h5web:main',
+        readOnly: true,
+        modelName: HDF5_FILE_TYPE.fileFormat,
+      })
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,37 +2,34 @@ import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
 } from '@jupyterlab/application';
+import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { createRendermimePlugins } from '@jupyterlab/application/lib/mimerenderers';
-// eslint-disable-next-line import/no-namespace
-import * as mimeExtension from './mimeplugin';
 import { IRenderMimeRegistry } from '@jupyterlab/rendermime';
 
+import { activateOpenInBrowser } from './browser';
 import HDF5_FILE_TYPE from './fileType';
-import H5webWidgetFactory from './widget';
+// eslint-disable-next-line import/no-namespace
+import * as mimeExtension from './mimeplugin';
 
 const extension: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab-h5web',
   autoStart: true,
-  requires: [IRenderMimeRegistry],
-  activate: (app: JupyterFrontEnd, rendermime: IRenderMimeRegistry): void => {
+  requires: [IFileBrowserFactory, IRenderMimeRegistry],
+  activate: (
+    app: JupyterFrontEnd,
+    factory: IFileBrowserFactory,
+    rendermime: IRenderMimeRegistry
+  ): void => {
     // eslint-disable-next-line no-console
     console.log('JupyterLab extension jupyterlab-h5web is activated!');
 
     app.docRegistry.addFileType(HDF5_FILE_TYPE);
 
-    app.docRegistry.addWidgetFactory(
-      new H5webWidgetFactory({
-        defaultFor: [HDF5_FILE_TYPE.name],
-        fileTypes: [HDF5_FILE_TYPE.name],
-        name: 'jupyterlab-h5web:main',
-        readOnly: true,
-        modelName: 'base64',
-      })
-    );
-
     const [mimePlugin] = createRendermimePlugins([mimeExtension]);
     app.registerPlugin(mimePlugin);
     mimePlugin.activate(app, rendermime);
+
+    activateOpenInBrowser(app, factory.defaultBrowser);
   },
 };
 

--- a/src/widget.tsx
+++ b/src/widget.tsx
@@ -8,7 +8,7 @@ import { ReactWidget } from '@jupyterlab/apputils';
 import { h5webIcon } from './icons';
 import H5webApp from './H5webApp';
 
-class H5webWidget extends ReactWidget {
+export class H5webWidget extends ReactWidget {
   private readonly filePath: string;
 
   public constructor(filePath: string) {


### PR DESCRIPTION
Related to #24 

If we use the JLab machinery to declare a h5web widget factory for hdf5 files, there is no way of disabling the blob fetching in JupyterLab 2 when opening the file through the browser. Work started in the right direction for JupyterLab 3 but it is a far cry from being fixed (see https://github.com/silx-kit/jupyterlab-h5web/issues/51#issuecomment-908350850).

As the blob fetching is a highly critical issue, I think our best move is to monkey-patch the opening as it was done in the early jupyterlab-h5web days (see the code removed by https://github.com/silx-kit/jupyterlab-h5web/pull/8).

This PR reverts https://github.com/silx-kit/jupyterlab-h5web/pull/8 but in a more sophisticated (I hope) manner:
- It uses `HDF5_FILE_TYPE` to get HDF5 model names and extensions to have `fileType.ts` the single source of truth for the file type.
- It patches **both** the double-click and the press on Enter in the browser that triggers file openings.
- After intercepting the event and detecting that the event does not point to a HDF5 file, it forwards `event` to the `listing.handleEvent` that handles the event "normally" (i.e. without interception).
- It keeps the previous code with `addWidgetFactory` gated behind a boolean for easy revert.

Obviously, this is far from ideal and it might have unintended side-effects that I did not catch but I feel this is a necessary evil.