### PR TITLE
Pin h5grove version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup_args = dict(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
-    install_requires=["jupyter_server>=1.6,<2", "h5grove>=0.0.11"],
+    install_requires=["jupyter_server>=1.6,<2", "h5grove==0.0.11"],
     extras_require={"full": ["hdf5plugin"]},
     python_requires=">=3.6",
     zip_safe=False,


### PR DESCRIPTION
As `h5grove` and `@h5web/app` are tightly coupled, I think it is better to pin both versions.