### PR TITLE
Fix the release workflow for JLab3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,8 @@ jobs:
           cp dist/*.tar.gz jupyterlab_h5web.tar.gz
           pip uninstall -y jupyterlab_h5web jupyterlab
           rm -rf jupyterlab_h5web
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: jupyterlab_h5web-dist
+          path: jupyterlab_h5web.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,40 +3,23 @@ name: Release
 on:
   push:
     tags:
-      - v*
+      - v1.*
 
 jobs:
+  build:
+    uses: silx-kit/jupyterlab-h5web/.github/workflows/build.yml@main
   release:
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🏷️
-        uses: actions/checkout@v2
-
-      - name: Match tag to package version 🧐
-        uses: geritol/match-tag-to-package-version@0.0.2
-        env:
-          TAG_PREFIX: refs/tags/v
-
-      - name: Use Node 14 🕹️
-        uses: actions/setup-node@v2
+      - name: Download the built extension
+        uses: actions/download-artifact@v2
         with:
-          node-version: '14'
-
-      - name: Install Python 🐍
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.6'
-          architecture: 'x64'
-
-      - name: Install dependencies ⚙️
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements_release.txt
+          name: jupyterlab_h5web-dist
+          path: dist
 
       - name: Publish package on PyPI 🎉
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+        run: twine upload dist/*

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -1,5 +1,0 @@
-setuptools
-wheel
-twine
-jupyterlab
-jupyter_packaging


### PR DESCRIPTION
I forgot to update the release workflow in #50.

The new build workflow already builds the extension and makes a bunch of checks so rather than copying the config, I made it [reusable](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows): https://github.com/silx-kit/jupyterlab-h5web/commit/43da2bd51cb5fbf16bc3f1f3567eaf32bb3b1bbb.

Then this PR:
- Re-adds the uploading of the built extension as artifact (it was originally in the [cookiecutter](https://github.com/jupyterlab/extension-cookiecutter-ts/blob/3.0/%7B%7Bcookiecutter.python_name%7D%7D/.github/workflows/build.yml#L69))
- Simplifies the release job that only calls the build job, downloads the resulting built package and uploads to PyPI

I may have to tweak a few things here and there when trying it for real, we will see.