### PR TITLE
Fix wrong encoding/decoding of big endians

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -32,7 +32,7 @@
     "    Xg, Yg = np.meshgrid(X, Y)\n",
     "    h5file['threeD'] = [np.sin(2*np.pi*f*np.sqrt(Xg**2 + Yg**2)) for f in np.arange(0.1, 1.1, 0.1)]\n",
     "    h5file['twoD'] = np.sin(np.sqrt(Xg**2 + Yg**2))\n",
-    "    h5file['oneD'] = X\n",
+    "    h5file.create_dataset('oneD', data=X, dtype='>f4')\n",
     "    h5file['scalar'] = 42"
    ]
   },

--- a/jupyterlab_h5web/handlers.py
+++ b/jupyterlab_h5web/handlers.py
@@ -62,9 +62,10 @@ class AttributeHandler(ContentHandler):
 class DataHandler(ContentHandler):
     def parse_content(self, content):
         selection = self.get_query_argument("selection", None)
+        dtype = self.get_query_argument("dtype", None)
 
         assert isinstance(content, DatasetContent)
-        return content.data(selection)
+        return content.data(selection, dtype=dtype)
 
 
 class MetadataHandler(ContentHandler):


### PR DESCRIPTION
Fix https://github.com/silx-kit/h5web/issues/1421#issuecomment-1515811198

When sending the data as binary, the blob is directly fed into a `TypedArray` in the JS part. Apparently, this only works if the original data was in little-endian order before encoding to binary.

In the `h5grove` demo, each time we fetch data in binary format, **we make sure that the data can be correctly decoded by using  the query parameter `dtype=safe`**:
1. It makes sure that it has a dtype that has equivalent in JS
2. _and that is is in little-endian order_

(see https://github.com/silx-kit/h5grove/blob/5b71298493ef180c4202bb2179cddd90316fb82d/h5grove/utils.py#L129 for the relevant method)

In the JupyterLab ext, I forgot to parse the `dtype` parameter so that this condition wasn't respected for big-endians. This PR fixes this.