### PR TITLE
include access token in client requests, if defined

### DIFF
--- a/src/H5webApp.tsx
+++ b/src/H5webApp.tsx
@@ -25,11 +25,14 @@ function TwoRenderApp() {
 
 function H5webApp(props: { filePath: string }) {
   const { filePath } = props;
-  const { baseUrl } = ServerConnection.makeSettings();
+  const { baseUrl, token } = ServerConnection.makeSettings();
 
   const axiosConfig = useMemo(
-    () => ({ params: { file: filePath } }),
-    [filePath]
+    () => ({
+      params: { file: filePath },
+      headers: token ? { Authorization: `token ${token}` } : {},
+    }),
+    [filePath, token]
   );
 
   return (


### PR DESCRIPTION
This allows h5web to work in a cross-site jupyterlab deployments (where backend and static pages are on different domains) and JupyterHub 4.1, which has stricter XSRF rules, and matches JupyterLab's own API requests made with ServerConnection.

Viewing hdf5 files results in a 403 error in these two scenarios without this patch.