### PR TITLE
Use React 18 renderer and fix empty cell bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@jupyterlab/services": "^7.0.0",
     "@jupyterlab/ui-components": "^4.0.0",
     "@lumino/widgets": "^2.0.0",
+    "@react-hookz/web": "^24.0.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },

--- a/src/H5WebInCell.tsx
+++ b/src/H5WebInCell.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import H5webApp from './H5webApp';
+import { useMeasure } from '@react-hookz/web';
+
+interface Props {
+  path: string;
+}
+
+function H5WebInCell(props: Props) {
+  const { path } = props;
+
+  // Wait for cell to have non-empty size so H5Web can render safely
+  const [rect, cellRef] = useMeasure<HTMLDivElement>();
+
+  return (
+    <div ref={cellRef} className="h5web-in-cell">
+      {rect && rect.width > 0 && <H5webApp filePath={path} />}
+    </div>
+  );
+}
+
+export default H5WebInCell;

--- a/src/H5webApp.tsx
+++ b/src/H5webApp.tsx
@@ -1,27 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { App, getFeedbackMailto, H5GroveProvider } from '@h5web/app';
 import { ServerConnection } from '@jupyterlab/services';
 
 const FEEDBACK_EMAIL = 'h5web@esrf.fr';
-
-function TwoRenderApp() {
-  const [isFirstRender, setIsFirstRender] = useState(true);
-
-  useEffect(() => {
-    setIsFirstRender(false);
-  }, []);
-
-  if (isFirstRender) {
-    return null;
-  }
-
-  return (
-    <App
-      getFeedbackURL={(context) => getFeedbackMailto(context, FEEDBACK_EMAIL)}
-      disableDarkMode
-    />
-  );
-}
 
 function H5webApp(props: { filePath: string }) {
   const { filePath } = props;
@@ -42,7 +23,12 @@ function H5webApp(props: { filePath: string }) {
         filepath={filePath}
         axiosConfig={axiosConfig}
       >
-        <TwoRenderApp />
+        <App
+          getFeedbackURL={(context) =>
+            getFeedbackMailto(context, FEEDBACK_EMAIL)
+          }
+          disableDarkMode
+        />
       </H5GroveProvider>
     </div>
   );

--- a/src/mimeplugin.tsx
+++ b/src/mimeplugin.tsx
@@ -2,10 +2,10 @@ import type { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 import { Widget } from '@lumino/widgets';
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
 import HDF5_FILE_TYPE from './fileType';
-import H5webApp from './H5webApp';
+import H5WebInCell from './H5WebInCell';
 
 class HDF5FilePathRenderer extends Widget implements IRenderMime.IRenderer {
   /* Renders HDF5 files from their path with H5web */
@@ -22,15 +22,8 @@ class HDF5FilePathRenderer extends Widget implements IRenderMime.IRenderer {
       throw new TypeError('Expected string');
     }
 
-    return new Promise<void>((resolve) => {
-      ReactDOM.render(
-        <div className="h5web-in-cell">
-          <H5webApp filePath={path} />
-        </div>,
-        this.node,
-        () => resolve()
-      );
-    });
+    createRoot(this.node).render(<H5WebInCell path={path} />);
+    return Promise.resolve();
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,7 +1329,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-hookz/web@npm:24.0.4":
+"@react-hookz/web@npm:24.0.4, @react-hookz/web@npm:^24.0.4":
   version: 24.0.4
   resolution: "@react-hookz/web@npm:24.0.4"
   dependencies:
@@ -5200,6 +5200,7 @@ __metadata:
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/ui-components": ^4.0.0
     "@lumino/widgets": ^2.0.0
+    "@react-hookz/web": ^24.0.4
     "@types/node": ^18.15.11
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0


### PR DESCRIPTION
### Issue

1. Render H5Web in a cell
2. Save the notebook
3. Reload or re-open the notebook

![image](https://github.com/silx-kit/jupyterlab-h5web/assets/2936402/a47aee50-65d4-4d13-aad0-7adb421ce808)

![image](https://github.com/silx-kit/jupyterlab-h5web/assets/2936402/4a130a54-ef22-4281-b491-f9fd109535c7)

### Fix

The `TwoRenderApp` was supposed to fix this empty-cell bug, but it wasn't robust to fix the reload use case above. I'm replacing it with a solution that consists in waiting until the cell has non-empty dimensions before rendering H5Web.

![image](https://github.com/silx-kit/jupyterlab-h5web/assets/2936402/031bd638-de54-4712-a97c-ebdef069116c)
