### PR TITLE
Split lint from build and update GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,19 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🏷️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Base Setup 🕹️ 🐍
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-      - name: Install dependencies ⚙️
+      - name: Install requirements ⚙️
         run: python -m pip install -U jupyterlab>=4.0 check-manifest
+
+      - name: Install dependencies ⚙️
+        run: jlpm install
 
       - name: Build the extension 🏗️
         run: |
           set -eux
-          jlpm
-          jlpm run lint
           python -m pip install .
 
           jupyter labextension list 2>&1 | grep -ie "jupyterlab-h5web.*OK"
@@ -41,14 +42,14 @@ jobs:
           rm -rf jupyterlab_h5web
 
       - name: Upload debug logs on failure 📬
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Build log
           path: |
             /tmp/*.log
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: jupyterlab_h5web-dist
           path: dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🏷️
+        uses: actions/checkout@v4
+
+      - name: Base Setup 🕹️ 🐍
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Install requirements ⚙️
+        run: python -m pip install -U jupyterlab>=4.0
+
+      - name: Install dependencies ⚙️
+        run: jlpm install
+
+      - name: Lint 🏗️
+        run: jlpm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download the built extension
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: jupyterlab_h5web-dist
           path: dist

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@jupyterlab/builder": "^4.0.0",
-    "@types/node": "^18.15.11",
+    "@types/node": "^20.14.9",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.55.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,21 +1603,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
+"@types/node@npm:*, @types/node@npm:^20.14.9":
   version: 20.14.9
   resolution: "@types/node@npm:20.14.9"
   dependencies:
     undici-types: ~5.26.4
   checksum: 5e9eda1ac8c6cc6bcd1063903ae195eaede9aad1bdad00408a919409cfbcdd2d6535aa3d50346f0d385528f9e03dafc7d1b3bad25aedb1dcd79a6ad39d06c35d
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^18.15.11":
-  version: 18.19.39
-  resolution: "@types/node@npm:18.19.39"
-  dependencies:
-    undici-types: ~5.26.4
-  checksum: d1de755983127b405458c427ae2cf77c89d120a617ca70999086a75fb0b6c6dbc1bdddfe1a8a7374c9ae55ed0589a2bd023ffb3b09ee25440c013afc6502dfe6
   languageName: node
   linkType: hard
 
@@ -5201,7 +5192,7 @@ __metadata:
     "@jupyterlab/ui-components": ^4.0.0
     "@lumino/widgets": ^2.0.0
     "@react-hookz/web": ^24.0.4
-    "@types/node": ^18.15.11
+    "@types/node": ^20.14.9
     "@types/react": ^18.0.0
     "@types/react-dom": ^18.0.0
     "@typescript-eslint/eslint-plugin": ^5.55.0


### PR DESCRIPTION
To speed up the CI a bit.

I've also made the `lint` and `build` status checks mandatory before merging is allowed.