### PR TITLE
Add "install:extension" command (again?) so that CONTRIBUTING commands go through

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True --source-map True .",
     "build:lib": "tsc --project tsconfig.build.json",
+    "install:extension": "jlpm build",
     "clean": "jlpm run clean:lib",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:labextension": "rimraf jupyterlab_h5web/labextension",


### PR DESCRIPTION
Without it, `pip install -e .` failed. But, I actually could not reproduce the error :sweat_smile: 

@axelboc Could you try to run the CONTRIBUTING commands on a fresh env to see if this MR is needed? 

